### PR TITLE
Fix Dockerfile user

### DIFF
--- a/openshift.yml
+++ b/openshift.yml
@@ -74,6 +74,7 @@ objects:
       dockerfile: |
         FROM scratch
         COPY . src
+        USER root
 
     strategy:
       dockerStrategy:


### PR DESCRIPTION
When try to build on Openshift 4.X, the /dev/stdout is a resource not
available, so it failed.

Root user need to be used.

Fix THREESCALE-5515

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>